### PR TITLE
LHG-206 Fix cdmiservice: Playready: Segmentation fault

### DIFF
--- a/cdmi/service.cpp
+++ b/cdmi/service.cpp
@@ -145,7 +145,7 @@ rpc_response_create_session* rpc_open_cdm_mediakeys_create_session_1_svc(
   static CDMi_RESULT cr = CDMi_S_FALSE;
   static rpc_response_create_session *response =
       reinterpret_cast<rpc_response_create_session*>(
-      malloc(sizeof(rpc_response_create_session)));
+      calloc(1, sizeof(rpc_response_create_session)));
 
   IMediaKeySessionCallback *callback = NULL;
   char *dst, *lic;


### PR DESCRIPTION
If non zero memory is returned from malloc() in
rpc_open_cdm_mediakeys_create_session_1_svc() then cdmiservice
can attempt to free() a non existent
response->licence_req.licence_req_val

Signed-off-by: Peter Griffin <peter.griffin@linaro.org>