### PR TITLE
cdmiservice: playready: *** Error in `/usr/bin/cdmiservice': malloc(): memory corruption: 0x0000000000765510LHG-205: 

### DIFF
--- a/cdmi/service.cpp
+++ b/cdmi/service.cpp
@@ -171,7 +171,8 @@ rpc_response_create_session* rpc_open_cdm_mediakeys_create_session_1_svc(
       uint32_t sid_size = strlen(sid);
       g_mediaKeySessions[sid] = p_mediaKeySession;
       dst = reinterpret_cast<char*>(malloc(sizeof(char) * sid_size));
-      strcpy(dst, sid);
+
+      strncpy(dst, sid, sid_size);
       response->session_id.session_id_val = dst;
       response->session_id.session_id_len = sid_size;
 


### PR DESCRIPTION
Fix malloc meta data corruption caused by strcpy, which results in the follow glibc message on the next malloc() call

 malloc(): memory corruption: 0x0000000000765510

Also update from cout to CDMI_LOG infrastructure.