### PR TITLE
Makefile.playready: remove lib not present in PRv3.3

### DIFF
--- a/cdmi/Makefile.playready
+++ b/cdmi/Makefile.playready
@@ -4,5 +4,4 @@ cdmiservice_LDADD += \
 	-lplayreadypk \
 	-lpritee \
 	-lteec\
-	-loem_linux \
-	-loemnw
+	-loem_linux


### PR DESCRIPTION
Signed-off-by: Peter Griffin <peter.griffin@linaro.org>