### PR TITLE
Changes for supporting WPE Browser

### DIFF
--- a/cdmi-stub/mediakeys.cpp
+++ b/cdmi-stub/mediakeys.cpp
@@ -35,7 +35,12 @@ CMediaKeys::~CMediaKeys(void) {}
 bool CMediaKeys::IsTypeSupported(
     const char *f_pwszMimeType,
     const char *f_pwszKeySystem) const {
-  bool isSupported = true;
+  bool isSupported = false;
+  if (f_pwszKeySystem)
+      if (strcmp(f_pwszKeySystem, "org.w3.clearkey") == 0 || strcmp(f_pwszKeySystem, "org.chromium.externalclearkey") == 0)
+          isSupported = true;
+
+  return isSupported;
 }
 
 const char * CMediaKeys::CreateSessionId() {

--- a/cdmi-stub/mediakeysession.cpp
+++ b/cdmi-stub/mediakeysession.cpp
@@ -154,10 +154,19 @@ void CMediaKeySession::Update(
   CDMI_DLOG() << "#mediakeysession.Run" << endl;
   std::string key_string(reinterpret_cast<const char*>(f_pbKeyMessageResponse),
                                    f_cbKeyMessageResponse);
-  //Session type is set to "0". We keep the function signature to
-  //match Chromium's ExtractKeysFromJWKSet(...) function
-  media::ExtractKeysFromJWKSet(key_string, &g_keys, 0);
-
+    
+  if (key_string.compare(0, 1, "{"))
+  {
+        CDMI_DLOG() << "KEY not in JSON format" << endl;
+        std::string key_id("1");       // dummy keyid for adding key_string to gkeys
+        media::KeyIdAndKeyPair key(key_id, key_string);
+        g_keys.assign(1, key);
+  }
+  else
+      //Session type is set to "0". We keep the function signature to
+      //match Chromium's ExtractKeysFromJWKSet(...) function
+      media::ExtractKeysFromJWKSet(key_string, &g_keys, 0);
+    
   ret = pthread_create(&thread, NULL, CMediaKeySession::_CallRunThread2, this);
   if (ret == 0) {
     pthread_detach(thread);

--- a/cdmi/service.cpp
+++ b/cdmi/service.cpp
@@ -115,8 +115,8 @@ rpc_response_generic* rpc_open_cdm_is_type_supported_1_svc(
        << type->key_system.key_system_val ;
   if (g_pMediaKeys) {
     cr = g_pMediaKeys->IsTypeSupported(
-      reinterpret_cast<char *>(type->key_system.key_system_val),
-       reinterpret_cast<char *>(type->mime_type.mime_type_val));
+      reinterpret_cast<char *>(type->mime_type.mime_type_val),
+       reinterpret_cast<char *>(type->key_system.key_system_val));
   } else {
     cr = CDMi_S_FALSE;
   }

--- a/rpc/opencdm_xdr.h
+++ b/rpc/opencdm_xdr.h
@@ -143,6 +143,10 @@ extern  rpc_response_generic * rpc_open_cdm_mediakeysession_release_1_svc(rpc_re
 extern  rpc_response_generic * rpc_open_cdm_mediaengine_1(rpc_request_mediaengine_data *, CLIENT *);
 extern  rpc_response_generic * rpc_open_cdm_mediaengine_1_svc(rpc_request_mediaengine_data *, struct svc_req *);
 extern int open_cdm_1_freeresult (SVCXPRT *, xdrproc_t, caddr_t);
+//WPE
+#define RPC_OPEN_CDM_MEDIAKEYS_SET_SERVER_CERTIFICATE 8
+#define RPC_OPEN_CDM_MEDIAKEYSESSION_REMOVE 9
+#define RPC_OPEN_CDM_MEDIAKEYSESSION_CLOSE 10
 
 #else /* K&R C */
 #define RPC_OPEN_CDM_IS_TYPE_SUPPORTED 1
@@ -167,6 +171,10 @@ extern  rpc_response_generic * rpc_open_cdm_mediakeysession_release_1_svc();
 extern  rpc_response_generic * rpc_open_cdm_mediaengine_1();
 extern  rpc_response_generic * rpc_open_cdm_mediaengine_1_svc();
 extern int open_cdm_1_freeresult ();
+//WPE
+#define RPC_OPEN_CDM_MEDIAKEYS_SET_SERVER_CERTIFICATE 8
+#define RPC_OPEN_CDM_MEDIAKEYSESSION_REMOVE 9
+#define RPC_OPEN_CDM_MEDIAKEYSESSION_CLOSE 10
 #endif /* K&R C */
 
 /* the xdr functions */


### PR DESCRIPTION
Changes for cdmiservice to work with WPE Browser after addressing the review comments from https://github.com/linaro-home/open-content-decryption-module-cdmi/pull/7