### PR TITLE
CDMi sdp support

### DIFF
--- a/cdmi-stub/mediakeysession.cpp
+++ b/cdmi-stub/mediakeysession.cpp
@@ -257,7 +257,7 @@ CDMi_RESULT CMediaKeySession::Decrypt(
 #else
   if(TEE_AES_ctr128_encrypt(reinterpret_cast<const unsigned char*>(f_pbData),
                      out, f_cbData, key,
-                     ivec, ecount_buf, &block_offset) !=0) {
+			    ivec, ecount_buf, &block_offset, 0, false) !=0) {
       CDMI_ELOG() << "ERROR: AES CTR128 Decryption failed\n";
       goto fail;
   }


### PR DESCRIPTION
TEE_AES_ctr128_encrypt() has been updated to take a "secure"
flag to indicate a SDP buffer. Also add the offset parameter
which is used by Android clearkeyplugin but not currently
by OpenCDM.

Signed-off-by: Peter Griffin <peter.griffin@linaro.org>